### PR TITLE
Use specified repository when looking up version

### DIFF
--- a/lib/puppet/provider/package/powershellcore.rb
+++ b/lib/puppet/provider/package/powershellcore.rb
@@ -97,7 +97,7 @@ Puppet::Type.type(:package).provide :powershellcore, parent: Puppet::Provider::P
   end
 
   def latest_command
-    "$mod = Find-Module #{@resource[:name]}; $mod.Version.ToString()"
+    "$mod = Find-Module #{@resource[:name]} -Repository #{@resource[:source]}; $mod.Version.ToString()"
   end
 
   def update_command


### PR DESCRIPTION
If multiple repositories exist and the same module exist in some of the repositories, the Find-Module command looks in all repositories and returns version as an array.

    ensure changed ['4.9.0'] to 'System.Object[]' (corrective)

To fix this use Find-Module with the '-Repository' parameter


Thanks to @brajjan

Cloned from: https://github.com/hbuckle/puppet-powershellmodule/pull/28