### PR TITLE
Add TLS 1.2 support for Windows PowerShell

### DIFF
--- a/lib/puppet/provider/package/windowspowershell.rb
+++ b/lib/puppet/provider/package/windowspowershell.rb
@@ -7,6 +7,8 @@ Puppet::Type.type(:package).provide(:windowspowershell, parent: :powershellcore)
 
   def self.invoke_ps_command(command)
     result = powershell(['-NoProfile', '-ExecutionPolicy', 'Bypass', '-NonInteractive', '-NoLogo', '-Command',
+                         # The following section of the -Command forces powershell to use tls1.2 (which it does not by default currently unless set system wide): [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+                         # Without tls1.2 you cannot install modules from PSGallery
                          "$ProgressPreference = 'SilentlyContinue'; $ErrorActionPreference = 'Stop'; [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; #{command}"])
     result.lines
   end

--- a/lib/puppet/provider/package/windowspowershell.rb
+++ b/lib/puppet/provider/package/windowspowershell.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:package).provide(:windowspowershell, parent: :powershellcore)
 
   def self.invoke_ps_command(command)
     result = powershell(['-NoProfile', '-ExecutionPolicy', 'Bypass', '-NonInteractive', '-NoLogo', '-Command',
-                         "$ProgressPreference = 'SilentlyContinue'; $ErrorActionPreference = 'Stop'; #{command}"])
+                         "$ProgressPreference = 'SilentlyContinue'; $ErrorActionPreference = 'Stop'; [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; #{command}"])
     result.lines
   end
 end

--- a/lib/puppet/provider/pspackageprovider/windowspowershell.rb
+++ b/lib/puppet/provider/pspackageprovider/windowspowershell.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:pspackageprovider).provide(:windowspowershell, parent: :power
 
   def self.invoke_ps_command(command)
     result = powershell(['-NoProfile', '-ExecutionPolicy', 'Bypass', '-NonInteractive', '-NoLogo', '-Command',
-                         "$ProgressPreference = 'SilentlyContinue'; $ErrorActionPreference = 'Stop'; #{command}"])
+                         "$ProgressPreference = 'SilentlyContinue'; $ErrorActionPreference = 'Stop'; [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; #{command}"])
     result.lines
   end
 end

--- a/lib/puppet/provider/pspackageprovider/windowspowershell.rb
+++ b/lib/puppet/provider/pspackageprovider/windowspowershell.rb
@@ -4,6 +4,8 @@ Puppet::Type.type(:pspackageprovider).provide(:windowspowershell, parent: :power
 
   def self.invoke_ps_command(command)
     result = powershell(['-NoProfile', '-ExecutionPolicy', 'Bypass', '-NonInteractive', '-NoLogo', '-Command',
+                         # The following section of the -Command forces powershell to use tls1.2 (which it does not by default currently unless set system wide): [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+                         # Without tls1.2 you cannot install modules from PSGallery
                          "$ProgressPreference = 'SilentlyContinue'; $ErrorActionPreference = 'Stop'; [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; #{command}"])
     result.lines
   end


### PR DESCRIPTION
Adds TLS 1.2 support for Windows PowerShell to allow using PowerShell Gallery. PowerShell Core already support TLS 1.2 so shouldn't have to specifically add it.

Fixes #6 