### PR TITLE
fix TLS1.2 enable command

### DIFF
--- a/lib/puppet/provider/psrepository/powershellcore.rb
+++ b/lib/puppet/provider/psrepository/powershellcore.rb
@@ -93,7 +93,7 @@ Puppet::Type.type(:psrepository).provide(:powershellcore) do
   def self.instances_command
     <<-COMMAND
     try {
-        [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
         @(Get-PSRepository -ErrorAction Stop -WarningAction Stop 3>$null).foreach({
             [ordered]@{
             'name' = $_.Name


### PR DESCRIPTION
The original command `[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12` fails with
```
 PS C:\> [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
Exception setting "SecurityProtocol": "The requested security protocol is not supported."
At line:1 char:1
+ [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolT ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
    + FullyQualifiedErrorId : ExceptionWhenSetting 
```