### PR TITLE
Require `puppet_x/helper.rb` based on full path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Development
 
+* Replaced the require call for `puppet_x` helper library to use a dynamically
+  expanded path. This works around limitations in Puppet Ruby `LOAD_PATH`
+  with error `no such file to load -- puppet_x/encore/powershellmodule/helper`.
+
+  Contributed by Valters Jansons (@sigv)
+
 ## 2.2.0 (2020-11-12)
 
 * Added PowerShell runtime caching using `ruby-pwsh` gem and the `puppetlabs/pwshlib` forge module

--- a/lib/puppet/provider/package/powershellcore.rb
+++ b/lib/puppet/provider/package/powershellcore.rb
@@ -1,6 +1,6 @@
 require 'puppet/provider/package'
 require 'json'
-require 'puppet_x/encore/powershellmodule/helper'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x', 'encore', 'powershellmodule', 'helper.rb'))
 
 Puppet::Type.type(:package).provide :powershellcore, parent: Puppet::Provider::Package do
   initvars

--- a/lib/puppet/provider/package/windowspowershell.rb
+++ b/lib/puppet/provider/package/windowspowershell.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/encore/powershellmodule/helper'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x', 'encore', 'powershellmodule', 'helper.rb'))
 
 Puppet::Type.type(:package).provide(:windowspowershell, parent: :powershellcore) do
   initvars

--- a/lib/puppet/provider/pspackageprovider/powershellcore.rb
+++ b/lib/puppet/provider/pspackageprovider/powershellcore.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'puppet_x/encore/powershellmodule/helper'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x', 'encore', 'powershellmodule', 'helper.rb'))
 
 Puppet::Type.type(:pspackageprovider).provide :powershellcore do
   confine operatingsystem: :windows

--- a/lib/puppet/provider/pspackageprovider/windowspowershell.rb
+++ b/lib/puppet/provider/pspackageprovider/windowspowershell.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/encore/powershellmodule/helper'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x', 'encore', 'powershellmodule', 'helper.rb'))
 
 Puppet::Type.type(:pspackageprovider).provide(:windowspowershell, parent: :powershellcore) do
   confine operatingsystem: :windows

--- a/lib/puppet/provider/psrepository/powershellcore.rb
+++ b/lib/puppet/provider/psrepository/powershellcore.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/encore/powershellmodule/helper'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x', 'encore', 'powershellmodule', 'helper.rb'))
 
 Puppet::Type.type(:psrepository).provide(:powershellcore) do
   initvars

--- a/lib/puppet/provider/psrepository/windowspowershell.rb
+++ b/lib/puppet/provider/psrepository/windowspowershell.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/encore/powershellmodule/helper'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x', 'encore', 'powershellmodule', 'helper.rb'))
 
 Puppet::Type.type(:psrepository).provide(:windowspowershell, parent: :powershellcore) do
   initvars


### PR DESCRIPTION
Not all code ends up in Puppet Ruby LOAD_PATH. We are running a fleet of Puppet 6.20.0 and Puppet 7.3.0 nodes, which cannot autoload `puppet/provider/package/windowspowershell` as there is no such file to load -- `puppet_x/encore/powershellmodule/helper`.

Using a dynamically expanded path from the `lib/puppet/` files seems to very much so do the trick. There was a 2012 O'Reilly book [Puppet Types and Providers (Chapter 4: Section "Shared Libraries")](https://www.oreilly.com/library/view/puppet-types-and/9781449339319/ch04.html) talking about this as well. Might not be the newest and greatest solution, as it would be possible to work with LOAD_PATH, but this solves the underlying catalog generation error.